### PR TITLE
Add PR webhook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ To start the AI Code Review Agent, run the following command:
 python src/main.py
 ```
 This will initialize the agent and start the API server, allowing you to submit PRs for review.
+## Webhook Integration
+Configure GitHub or Bitbucket to call the API whenever a pull request is created.
+
+- **GitHub**: send 'pull_request' events to '/webhook/github'.
+- **Bitbucket**: send 'pullrequest:created' events to '/webhook/bitbucket'.
+
+Set 'GITHUB_TOKEN' and 'BITBUCKET_TOKEN' environment variables so the server can fetch PR diffs.
+
 
 ## Contributing
 Contributions are welcome! Please follow these steps:

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Header, HTTPException
 from agent import ReviewAgent, RiskAnalyzer, LanguageDetector, StaticAnalyzer
 from agent.graph import create_review_graph
+from integrations.github import GitHubClient
+from integrations.bitbucket import BitbucketClient
 
 router = APIRouter()
 
@@ -9,6 +11,8 @@ risk_analyzer = RiskAnalyzer()
 language_detector = LanguageDetector()
 static_analyzer = StaticAnalyzer()
 review_graph = create_review_graph()
+github_client = GitHubClient()
+bitbucket_client = BitbucketClient()
 
 
 @router.post("/review")
@@ -33,6 +37,34 @@ async def perform_static_analysis(pr: dict):
 @router.post("/full-review")
 async def perform_full_review(pr: dict):
     return review_graph.invoke({"pr": pr})
+
+
+@router.post("/webhook/github")
+async def github_webhook(payload: dict, x_github_event: str = Header(None)):
+    if x_github_event != "pull_request" or payload.get("action") != "opened":
+        return {"status": "ignored"}
+    try:
+        repo = payload["repository"]["full_name"]
+        pr_number = payload["number"] if "number" in payload else payload["pull_request"]["number"]
+        diff = github_client.fetch_pr_diff(repo, pr_number)
+        result = review_graph.invoke({"pr": {"code": diff}})
+        return result
+    except Exception as exc:  # pragma: no cover - network failures
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.post("/webhook/bitbucket")
+async def bitbucket_webhook(payload: dict, x_event_key: str = Header(None)):
+    if x_event_key != "pullrequest:created":
+        return {"status": "ignored"}
+    try:
+        repo = payload["repository"]["full_name"]
+        pr_id = payload["pullrequest"]["id"]
+        diff = bitbucket_client.fetch_pr_diff(repo, pr_id)
+        result = review_graph.invoke({"pr": {"code": diff}})
+        return result
+    except Exception as exc:  # pragma: no cover - network failures
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 def setup_routes(app):

--- a/src/config.py
+++ b/src/config.py
@@ -17,4 +17,8 @@ class Config:
     # Risk analysis settings
     RISK_ANALYSIS_ENABLED = os.getenv('RISK_ANALYSIS_ENABLED', 'true').lower() == 'true'
 
+    # Integration tokens
+    GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
+    BITBUCKET_TOKEN = os.getenv('BITBUCKET_TOKEN')
+
     # Other settings can be added here as needed

--- a/src/integrations/bitbucket.py
+++ b/src/integrations/bitbucket.py
@@ -1,0 +1,23 @@
+import os
+import requests
+
+
+class BitbucketClient:
+    """Simple Bitbucket API client for fetching pull request data."""
+
+    def __init__(self, token: str | None = None):
+        self.token = token or os.getenv("BITBUCKET_TOKEN")
+        self.base_url = "https://api.bitbucket.org/2.0"
+
+    def _headers(self) -> dict:
+        headers = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def fetch_pr_diff(self, repo_full_name: str, pr_id: int) -> str:
+        """Return the diff for the pull request as text."""
+        url = f"{self.base_url}/repositories/{repo_full_name}/pullrequests/{pr_id}/diff"
+        response = requests.get(url, headers=self._headers(), timeout=10)
+        response.raise_for_status()
+        return response.text

--- a/src/integrations/github.py
+++ b/src/integrations/github.py
@@ -1,0 +1,23 @@
+import os
+import requests
+
+
+class GitHubClient:
+    """Simple GitHub API client for fetching pull request data."""
+
+    def __init__(self, token: str | None = None):
+        self.token = token or os.getenv("GITHUB_TOKEN")
+        self.base_url = "https://api.github.com"
+
+    def _headers(self) -> dict:
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        return headers
+
+    def fetch_pr_diff(self, repo_full_name: str, pr_number: int) -> str:
+        """Return the diff for the pull request as text."""
+        url = f"{self.base_url}/repos/{repo_full_name}/pulls/{pr_number}.patch"
+        response = requests.get(url, headers=self._headers(), timeout=10)
+        response.raise_for_status()
+        return response.text

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from api.routes import setup_routes
+from .api.routes import setup_routes
 
 
 def create_app() -> FastAPI:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+from src.main import create_app
+
+
+class DummyGitHubClient:
+    def fetch_pr_diff(self, repo, pr_number):
+        return "diff --git a/foo.py b/foo.py\n+print('hi')"
+
+
+class DummyBitbucketClient:
+    def fetch_pr_diff(self, repo, pr_number):
+        return "diff --git a/bar.py b/bar.py\n+print('hi')"
+
+
+def test_github_webhook(monkeypatch):
+    app = create_app()
+    from src.api import routes
+    monkeypatch.setattr(routes, "github_client", DummyGitHubClient())
+    client = TestClient(app)
+    payload = {
+        "action": "opened",
+        "number": 1,
+        "repository": {"full_name": "owner/repo"},
+        "pull_request": {"number": 1},
+    }
+    headers = {"X-GitHub-Event": "pull_request"}
+    response = client.post("/webhook/github", json=payload, headers=headers)
+    assert response.status_code == 200
+    assert "review" in response.json()
+
+
+def test_bitbucket_webhook(monkeypatch):
+    app = create_app()
+    from src.api import routes
+    monkeypatch.setattr(routes, "bitbucket_client", DummyBitbucketClient())
+    client = TestClient(app)
+    payload = {
+        "repository": {"full_name": "owner/repo"},
+        "pullrequest": {"id": 1},
+    }
+    headers = {"X-Event-Key": "pullrequest:created"}
+    response = client.post("/webhook/bitbucket", json=payload, headers=headers)
+    assert response.status_code == 200
+    assert "review" in response.json()


### PR DESCRIPTION
## Summary
- handle GitHub and Bitbucket pull request events
- fetch diff with new integration clients
- expose `/webhook/github` and `/webhook/bitbucket`
- document webhook usage in README
- test webhook routes

## Testing
- `pip install -q numpy`
- `pip install -q pygments httpx lizard requests fastapi uvicorn pytest`
- `pip install -q langgraph`
- `pytest -q` *(fails: ImportError: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_6849d1355e188329a9ba96b6d11f9073